### PR TITLE
fix: comments sort reverse

### DIFF
--- a/src/#/@common/task-form/task-comments/task-comments.tsx
+++ b/src/#/@common/task-form/task-comments/task-comments.tsx
@@ -66,7 +66,7 @@ export const TaskComments: React.FC<IProps> = ({
       fetchTaskComments(curTask.projectId, curTask.id)
         .then((comments: IComment[]) => {
           setIsFetching(false);
-          setTaskComments(comments);
+          setTaskComments(comments.reverse());
         })
         .catch(() => {
           setIsFetching(false);
@@ -146,6 +146,7 @@ export const TaskComments: React.FC<IProps> = ({
                           </Tooltip>
                         </span>
                       )}
+                      {new Date(comment.createdAt).toLocaleString()}
                       {isCommentRemove && comment.id === removedCommentId && (
                         <div className={classes.circularRemoveWrap}>
                           <CircularProgress />


### PR DESCRIPTION
1. После получения комментариев они инвертируются.
2. Добавлена дата создания

Думал сделать сортировку по дате, но я скорее всего это уже реализовано на бекенде.
Предложение: сортировку можно сделать на бекенде добавив ORDER BY  