### PR TITLE
fix: the ability to add a role

### DIFF
--- a/src/#/#/#projects/#-projectId/#roles/project.roles.tsx
+++ b/src/#/#/#projects/#-projectId/#roles/project.roles.tsx
@@ -22,7 +22,7 @@ export interface IProjectMembersProps extends RouteComponentProps {
 
 const COLUMNS: ICrudColumn[] = [
   { title: 'ID', path: 'id', isNumber: true },
-  { title: 'Название', path: 'role.id' },
+  { title: 'Название', path: 'role.id', name: 'roleId' },
   { title: 'Публичная', path: 'isPublic', name: 'isPublic', isBoolean: true, component: CheckboxCell },
 ];
 


### PR DESCRIPTION
После прошедшего коммита пропала возможность добавить роль в проект. Данный коммит возвращает данную возможность, но влечёт за собой баг (при открытии поля для редактирование сам title роли не должен быть доступен для редактирования), который нужно будет исправить